### PR TITLE
fix: Resolve variable name conflict in advanced-lipsync-service

### DIFF
--- a/src/lib/services/advanced-lipsync-service.ts
+++ b/src/lib/services/advanced-lipsync-service.ts
@@ -237,11 +237,11 @@ export class AdvancedLipSyncService {
           };
 
           const candidates = numberMappings[shape] || [];
-          let _foundNumberAlternative = false;
+          let _foundNumberCandidate = false;
           for (const candidate of candidates) {
             if (this.isBlendShapeAvailable(candidate)) {
               adjustedBlendShapes[candidate] = finalWeight;
-              _foundNumberAlternative = true;
+              _foundNumberCandidate = true;
               break;
             }
           }


### PR DESCRIPTION
## Summary
Fixes a variable name conflict that caused a compilation error in the development server.

## Problem
After the console log cleanup, there was a variable shadowing issue where `_foundNumberAlternative` was defined in two different scopes within the same function, causing:
```
the name `_foundNumberAlternative` is defined multiple times
```

## Solution
- Renamed the second instance to `_foundNumberCandidate` to avoid naming conflict
- Maintains all existing functionality 
- Resolves compilation error

## Changes Made
- **File**: `src/lib/services/advanced-lipsync-service.ts`
- **Change**: Renamed variable in line 240 from `_foundNumberAlternative` to `_foundNumberCandidate`

## Test Plan
- [x] Development server starts without errors
- [x] No functionality changes
- [x] Variable scoping properly isolated

## Related
Follow-up fix for the console log cleanup PR #36

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved variable naming for better code clarity. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->