### PR TITLE
feat: 設定ページをモーダル化 (#45)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@ai-sdk/google": "^1.2.19",
         "@google/generative-ai": "^0.24.1",
         "@pixiv/three-vrm": "^3.4.1",
+        "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slider": "^1.3.5",
@@ -337,6 +338,8 @@
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 
     "@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.1.14", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.10", "@radix-ui/react-focus-guards": "1.1.2", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.4", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw=="],
 
     "@radix-ui/react-direction": ["@radix-ui/react-direction@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw=="],
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@ai-sdk/google": "^1.2.19",
     "@google/generative-ai": "^0.24.1",
     "@pixiv/three-vrm": "^3.4.1",
+    "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slider": "^1.3.5",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import { ErrorBoundary } from "@/components/error/error-boundary";
 import { useModelStore } from "@/lib/stores/model-store";
 import { Button } from "@/components/ui/button";
 import { AnimationController } from "@/lib/services/animation-controller";
-import Link from "next/link";
+import { SettingsModal } from "@/components/settings/settings-modal";
 
 // カメラデバッグパネルコンポーネント
 function CameraDebugPanel() {
@@ -107,6 +107,7 @@ const initializeAnimationController = () => {
 
 export default function Home() {
   const [isVoiceChatActive, setIsVoiceChatActive] = useState(false);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 
   // 音声チャット関連の状態
   const [audioChatService, setAudioChatService] =
@@ -314,16 +315,15 @@ export default function Home() {
                 v1.0.0
               </span>
             </div>
-            <Link href="/settings">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="flex items-center gap-2"
-              >
-                <Settings className="w-4 h-4" />
-                設定
-              </Button>
-            </Link>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setIsSettingsOpen(true)}
+              className="flex items-center gap-2"
+            >
+              <Settings className="w-4 h-4" />
+              設定
+            </Button>
           </div>
         </div>
       </header>
@@ -374,12 +374,13 @@ export default function Home() {
                 <br />
                 音声会話を始めましょう
               </p>
-              <Link href="/settings">
-                <Button className="w-full flex items-center gap-2">
-                  <Settings className="w-4 h-4" />
-                  モデルを読み込む
-                </Button>
-              </Link>
+              <Button
+                onClick={() => setIsSettingsOpen(true)}
+                className="w-full flex items-center gap-2"
+              >
+                <Settings className="w-4 h-4" />
+                モデルを読み込む
+              </Button>
               <div className="mt-3 text-xs text-gray-500">
                 設定ページでVRM、glTF、GLBファイルを選択
               </div>
@@ -445,16 +446,18 @@ export default function Home() {
           <div className="text-center mt-3">
             <p className="text-xs text-gray-500">
               3Dモデルと音声で会話できます •
-              <Link
-                href="/settings"
+              <button
+                onClick={() => setIsSettingsOpen(true)}
                 className="text-blue-600 hover:underline ml-1"
               >
                 詳細設定はこちら
-              </Link>
+              </button>
             </p>
           </div>
         </div>
       </footer>
+
+      <SettingsModal isOpen={isSettingsOpen} onOpenChange={setIsSettingsOpen} />
     </main>
   );
 }

--- a/src/components/settings/settings-modal.tsx
+++ b/src/components/settings/settings-modal.tsx
@@ -1,66 +1,51 @@
 "use client";
 
-import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ModelSelector } from "@/components/3d/model-selector";
-import Chat from "../../components/chat";
-import {
-  Settings,
-  MessageCircle,
-  ArrowLeft,
-  Box,
-} from "lucide-react";
+import Chat from "../chat";
+import { Box, MessageCircle } from "lucide-react";
 import { ErrorBoundary } from "@/components/error/error-boundary";
-import { Button } from "@/components/ui/button";
-import Link from "next/link";
 import { useModelStore } from "@/lib/stores/model-store";
 import { loadModel } from "@/lib/3d/loaders";
 
-export default function SettingsPage() {
-  const [activeTab, setActiveTab] = useState("models");
+interface SettingsModalProps {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+}
 
-  // モデルストアから必要な関数を取得
+export function SettingsModal({ isOpen, onOpenChange }: SettingsModalProps) {
   const {
     availableModels,
     currentModel,
     isLoading,
     addModel,
     removeModel,
-    setCurrentModel,
     switchToModel,
     setLoading,
     setError,
   } = useModelStore();
 
   return (
-    <main className="min-h-screen bg-gray-50">
-      <div className="container mx-auto p-4 max-w-4xl">
-        {/* ヘッダー */}
-        <header className="mb-6">
-          <div className="flex items-center gap-3 mb-4">
-            <Link href="/">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="flex items-center gap-2"
-              >
-                <ArrowLeft className="w-4 h-4" />
-                戻る
-              </Button>
-            </Link>
-            <Settings className="w-8 h-8 text-blue-600" />
-            <h1 className="text-3xl font-bold text-gray-900">設定</h1>
-          </div>
-          <p className="text-gray-600">3Dモデルの管理とAI設定を行います</p>
-        </header>
-
-        {/* 設定タブ */}
-        <div className="bg-white rounded-lg shadow-lg">
-          <Tabs
-            value={activeTab}
-            onValueChange={setActiveTab}
-            className="h-full"
-          >
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl max-h-[90vh] bg-white/90 backdrop-blur-sm overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="text-2xl font-bold text-gray-900">
+            設定
+          </DialogTitle>
+          <DialogDescription>
+            3Dモデルの管理とAI設定を行います
+          </DialogDescription>
+        </DialogHeader>
+        
+        <div className="mt-4">
+          <Tabs defaultValue="models" className="h-full">
             <TabsList className="grid w-full grid-cols-2 p-1">
               <TabsTrigger value="models" className="flex items-center gap-2">
                 <Box className="w-4 h-4" />
@@ -73,13 +58,13 @@ export default function SettingsPage() {
             </TabsList>
 
             {/* 3Dモデル管理タブ */}
-            <TabsContent value="models" className="p-6">
+            <TabsContent value="models" className="p-4">
               <div className="space-y-6">
                 <div>
-                  <h2 className="text-xl font-semibold text-gray-800 mb-4">
+                  <h3 className="text-lg font-semibold text-gray-800 mb-2">
                     3Dモデル管理
-                  </h2>
-                  <p className="text-gray-600 mb-4">
+                  </h3>
+                  <p className="text-sm text-gray-600 mb-4">
                     VRM、glTF、GLBファイルをアップロードして使用できます
                   </p>
                   <div className="bg-gray-50 rounded-lg p-4">
@@ -92,21 +77,17 @@ export default function SettingsPage() {
                           try {
                             setLoading(true);
                             setError(undefined);
-
                             const result = await loadModel(file);
                             if (result.success && result.model) {
                               addModel(result.model);
-                              setCurrentModel(result.model);
                             } else {
-                              throw new Error(
-                                result.error || "モデルの読み込みに失敗しました"
-                              );
+                              throw new Error(result.error || "モデルの読み込みに失敗");
                             }
                           } catch (error) {
                             const errorMessage =
                               error instanceof Error
                                 ? error.message
-                                : "不明なエラーが発生しました";
+                                : "不明なエラーが発生";
                             setError(errorMessage);
                           } finally {
                             setLoading(false);
@@ -122,13 +103,13 @@ export default function SettingsPage() {
             </TabsContent>
 
             {/* AI設定タブ */}
-            <TabsContent value="ai" className="p-6">
+            <TabsContent value="ai" className="p-4">
               <div className="space-y-6">
                 <div>
-                  <h2 className="text-xl font-semibold text-gray-800 mb-4">
+                  <h3 className="text-lg font-semibold text-gray-800 mb-2">
                     AI チャット設定
-                  </h2>
-                  <p className="text-gray-600 mb-4">
+                  </h3>
+                  <p className="text-sm text-gray-600 mb-4">
                     Google Gemini APIの設定を行います
                   </p>
                   <div className="bg-gray-50 rounded-lg p-4">
@@ -141,8 +122,7 @@ export default function SettingsPage() {
             </TabsContent>
           </Tabs>
         </div>
-
-      </div>
-    </main>
+      </DialogContent>
+    </Dialog>
   );
-}
+} 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}


### PR DESCRIPTION
・/settingsページを削除し、SettingsModalコンポーネントにリファクタリング
・ルートページに設定ボタンを配置し、モーダルで設定画面を開くように変更
・古いLinkコンポーネントを削除し、モーダルを開くトリガーに統一

Close #45 #44 